### PR TITLE
Callback support and filtered inappropriate headers from prerender service.

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -155,7 +155,6 @@ module Rack
       # Pass through only applicable 
       prerendered_response.each do |name, val|
         next if DISALLOWED_PHANTOMJS_HEADERS.include? name
-        Rails.logger.debug "Prerender response header: #{name} #{val}"
         response[name] = val
       end
 


### PR DESCRIPTION
The latency added by sending an HTTP request to the prerender service for every single crawlable request is not scalable. I had a need to actual do the cache setting and getting from the middleware.

Previously I had monkey patched this behavior but I went ahead and added it to the prerender_rails gem.

I also fixed a bug in the latest version that would leave requests open and hanging due to Content-Length mis-matches. I went ahead and added a constant to filter out headers we don't actually want from the prerender service.

Let me know if this is something you'd like to merge and I can add documentation for the callbacks.
