### PR TITLE
Add missing activesupport dependency

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -1,6 +1,7 @@
 module Rack
   class Prerender
     require 'net/http'
+    require 'active_support'
 
     def initialize(app, options={})
       # googlebot, yahoo, and bingbot are not in this list because

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rack', '>= 0'
+  spec.add_dependency 'activesupport', '>= 0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Now this gem can play well with sinatra or other rack-compatible framework. 
Add  `use Rack::Prerender` to config.ru before `run App` line.
