### PR TITLE
Add Google Plus snippet bot to user agents list

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -20,7 +20,8 @@ module Rack
         'quora link preview',
         'showyoubot',
         'outbrain',
-        'pinterest'
+        'pinterest',
+        'developers.google.com/+/web/snippet'
       ]
 
       @extensions_to_ignore = [


### PR DESCRIPTION
[Google's snippet crawler](https://developers.google.com/+/web/snippet/) fetches page information for links shared on Google Plus. It does does not seem to support _escape_fragement_.

Unlike `facebookexternalhit` and `linkedinbot` the User Agent does not have a friendly bot name (`Google (+https://developers.google.com/+/web/snippet/)` could be confused with googlebot, et al.), so a uniquely identifiable component of the full value is used: `developers.google.com/+/web/snippet/`.

Let me know if there are any questions! It'd be great to see these changes incorporated to make social sharing nearly thoughtless.
