### PR TITLE
Optionally disable prerendering for Googlebot

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -74,6 +74,7 @@ module Rack
       @options[:blacklist] = [@options[:blacklist]] if @options[:blacklist].is_a? String
       @extensions_to_ignore = @options[:extensions_to_ignore] if @options[:extensions_to_ignore]
       @crawler_user_agents = @options[:crawler_user_agents] if @options[:crawler_user_agents]
+      @smart_googlebot = @options[:smart_googlebot]
       @app = app
     end
 
@@ -107,6 +108,7 @@ module Rack
 
       return false if !user_agent
       return false if env['REQUEST_METHOD'] != 'GET'
+      return false if @smart_googlebot && user_agent.downcase == 'googlebot'
 
       request = Rack::Request.new(env)
 


### PR DESCRIPTION
According to http://googlewebmastercentral.blogspot.com/2014/05/understanding-web-pages-better.html Googlebot is able to execute the whole JavaScript without the need for prerendering. This PR's adds an option to disable prerendering when Googlebot is detected. I have been using this approach in production and works great so far, prerendering sites for bing and other less clever bots, while serving the real website for Google without the prerender overhead.