### PR TITLE
Add Qwantify to crawler list

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -28,7 +28,8 @@ module Rack
         'vkShare',
         'W3C_Validator',
         'redditbot',
-        'Applebot'
+        'Applebot',
+        'Qwantify'
       ]
 
       @extensions_to_ignore = [


### PR DESCRIPTION
Search engine is https://www.qwant.com/. User agent is
Mozilla/5.0 (compatible; Qwantify/2.3w; +https://www.qwant.com/)/2.3w