### PR TITLE
feat(crawling): re add googlebot for better crawling

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -8,9 +8,9 @@ module Rack
       # we support _escaped_fragment_ and want to ensure people aren't
       # penalized for cloaking.
       @crawler_user_agents = [
-        # 'googlebot',
-        # 'yahoo',
-        # 'bingbot',
+        'googlebot',
+        'yahoo',
+        'bingbot',
         'baiduspider',
         'facebookexternalhit',
         'twitterbot',


### PR DESCRIPTION
Since GoogleBot doesn't use `escaped_fragment` anymore, GoogleBot should be detected with UserAgent detection again.

Anyway, is this library still maintained ?