### PR TITLE
Do not check blacklist/whitelist if is_requesting_prerendered_page is false

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -131,6 +131,8 @@ module Rack
       #if it is Prerender...don't show prerendered page
       is_requesting_prerendered_page = false if prerender_agent
 
+      return false unless is_requesting_prerendered_page
+
       #if it is a bot and is requesting a resource...dont prerender
       return false if @extensions_to_ignore.any? { |extension| request.fullpath.include? extension }
 


### PR DESCRIPTION
The purpose of this PR is to improve the performance of something as critical as a middleware, which is executed in every request.

According to the code, the blacklist and whitelist options are checked even if `is_requesting_prerendered_page` variable is false. This does not make sense, since once this variable is false after the initial checks (no _escaped_fragment_, no crawler, no buffer agent) we know that the prerendered page will not be used.