### PR TITLE
Improve user agents check performance, avoid so many calls to String#downcase

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -117,19 +117,16 @@ module Rack
 
       return false if !user_agent
       return false if env['REQUEST_METHOD'] != 'GET'
+      #if it is Prerender...don't show prerendered page
+      return false if prerender_agent
 
       request = Rack::Request.new(env)
 
-      is_requesting_prerendered_page = true if Rack::Utils.parse_query(request.query_string).has_key?('_escaped_fragment_')
-
-      #if it is a bot...show prerendered page
-      is_requesting_prerendered_page = true if @crawler_user_agents.any? { |crawler_user_agent| user_agent.downcase.include?(crawler_user_agent.downcase) }
-
-      #if it is BufferBot...show prerendered page
-      is_requesting_prerendered_page = true if buffer_agent
-
-      #if it is Prerender...don't show prerendered page
-      is_requesting_prerendered_page = false if prerender_agent
+      # if it is BufferBot, escaped fragment or bot
+      # -> ready for prerender: check extensions, blacklist and whitelist
+      # else
+      # -> return false, will not be prerendered
+      return false unless buffer_agent || escaped_fragment?(request) || crawler?(user_agent)
 
       #if it is a bot and is requesting a resource...dont prerender
       return false if @extensions_to_ignore.any? { |extension| request.fullpath.include? extension }
@@ -151,7 +148,7 @@ module Rack
         return false
       end
 
-      return is_requesting_prerendered_page
+      true
     end
 
 
@@ -233,10 +230,23 @@ module Rack
       end
     end
 
-
     def after_render(env, response)
       return true unless @options[:after_render]
       @options[:after_render].call(env, response)
+    end
+
+    def escaped_fragment?(request)
+      Rack::Utils.parse_query(request.query_string).has_key?('_escaped_fragment_')
+    end
+
+    def crawler?(user_agent)
+      user_agent = user_agent.downcase
+
+      crawler_user_agents.any? { |crawler_user_agent| user_agent.include?(crawler_user_agent) }
+    end
+
+    def crawler_user_agents
+      @downcased_crawler_user_agents ||= @crawler_user_agents.map(&:downcase)
     end
   end
 end


### PR DESCRIPTION
This MR improves the performance by reordering the checks, skipping unneeded checks and reducing the number of calls to the String#downcase method.

- Previous code checked if bot, escaped_string or buffer bot and, after, it set the variable `is_requesting_prerendered_page` to false if `prerender_agent`. `prerender_agent` is obtained from an enviroment variable (`env['HTTP_X_PRERENDER']`) that we know in advance, so we could return false as part of the initial validations (at the same level as validation of user agent and GET request).

- All the conditions in charge of setting the variable to true were executed even if the variable was true already. For example, `is_requesting_prerendered_page` would be true if escaped_string, but even knowing that's true, the user agent was checked against the crawler user agents.

- The order in which conditions are checked has been modified according to the cost of execution.

- The array of crawler user agents is converted to downcase, before this was done on each execution of the `user_agent.include?(crawler_user_agent)`. Also the request user agent was converted to downcase on each iteration. That means that for each not crawler, String#downcase was invoked 60 times (30 crawler user agents * 2 times).