### PR TITLE
Add Chrome-Lighthouse (Google Page Speed Insights) to user agent list

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -34,7 +34,8 @@ module Rack
         'nuzzel',
         'Discordbot',
         'Google Page Speed',
-        'Qwantify'
+        'Qwantify',
+        'Chrome-Lighthouse'
       ]
 
       @extensions_to_ignore = [


### PR DESCRIPTION
Google Page Speed Insights it's using as user_agent: Chrome-Lighthouse so i added the user agent

https://developers.google.com/speed/pagespeed/insights

Full User Agents
"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Safari/537.36 Chrome-Lighthouse",
"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Mobile Safari/537.36 Chrome-Lighthouse"