### PR TITLE
use on not boolean true when protocol is https

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -196,7 +196,7 @@ module Rack
       end
 
       if @options[:protocol]
-        new_env["HTTPS"] = true and new_env["rack.url_scheme"] = "https" and new_env["SERVER_PORT"] = 443 if @options[:protocol] == "https"
+        new_env["HTTPS"] = 'on' and new_env["rack.url_scheme"] = "https" and new_env["SERVER_PORT"] = 443 if @options[:protocol] == "https"
         new_env["HTTPS"] = false and new_env["rack.url_scheme"] = "http" and new_env["SERVER_PORT"] = 80 if @options[:protocol] == "http"
       end
 


### PR DESCRIPTION
In Rack, [here](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L210) shows that it will check `get_header(HTTPS) == 'on'` to return https scheme. 
In [Prerender Rails](https://github.com/prerender/prerender_rails/blob/master/lib/prerender_rails.rb#L199), it was set to boolean true not `on`. The mismatch result in the forwarded_scheme block. Which caused the protocol issue.