### PR TITLE
use on instead of true to be consistent with rack

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -196,8 +196,8 @@ module Rack
       end
 
       if @options[:protocol]
-        new_env["HTTPS"] = true and new_env["rack.url_scheme"] = "https" and new_env["SERVER_PORT"] = 443 if @options[:protocol] == "https"
-        new_env["HTTPS"] = false and new_env["rack.url_scheme"] = "http" and new_env["SERVER_PORT"] = 80 if @options[:protocol] == "http"
+        new_env["HTTPS"] = 'on' and new_env["rack.url_scheme"] = "https" and new_env["SERVER_PORT"] = 443 if @options[:protocol] == "https"
+        new_env["HTTPS"] = 'off' and new_env["rack.url_scheme"] = "http" and new_env["SERVER_PORT"] = 80 if @options[:protocol] == "http"
       end
 
       url = Rack::Request.new(new_env).url


### PR DESCRIPTION
Rack uses `on` to check if it's HTTPS([link](https://github.com/rack/rack/blob/1-6-stable/lib/rack/request.rb#L68)):
```
if @env['HTTPS'] == 'on'
        'https'
```

If the host and port don't match, Rack will add the port to the URL, so we override `HTTP_X_FORWARDED_PROTO` and `rack.url_scheme`. 

This fix has been verified working on our infrastructure as mentioned in our email exchange.