### PR TITLE
Fix handling hop-by-hop headers

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -4,6 +4,19 @@ module Rack
     require 'active_support'
 
     def initialize(app, options={})
+      @connection_header_values = [
+        'close',
+        'keep-alive'
+      ].freeze
+      @hop_by_hop_headers = [
+        'Connection',
+        'Keep-Alive',
+        'Public',
+        'Proxy-Authenticate',
+        'Transfer-Encoding',
+        'Upgrade'
+      ].freeze
+
       @crawler_user_agents = [
         'googlebot',
         'yahoo',
@@ -175,6 +188,19 @@ module Rack
           response['Content-Length'] = response.body.length
           response.delete('Content-Encoding')
         end
+
+        hop_by_hop_headers = @hop_by_hop_headers
+        connection = response['Connection']
+        if connection
+          connection_hop_by_hop_headers = connection.split(',').
+                                            map(&:strip).
+                                            map(&:downcase).
+                                            difference(@connection_header_values)
+          hop_by_hop_headers = connection_hop_by_hop_headers.
+                                 concat(hop_by_hop_headers)
+        end
+        hop_by_hop_headers.each { |h| response.delete(h) }
+
         response
       rescue
         nil

--- a/test/lib/prerender_rails.rb
+++ b/test/lib/prerender_rails.rb
@@ -159,6 +159,42 @@ describe Rack::Prerender do
     assert_equal( { 'test' => 'test2Header'}, response[1] )
   end
 
+  it "should return a prerendered response stripped of hop-by-hop headers" do
+    request = Rack::MockRequest.env_for "/", "HTTP_USER_AGENT" => bot
+    stub_request(:get, @prerender.build_api_url(request)).
+      with(:headers => { 'User-Agent' => bot }).
+      to_return(:body => "<html></html>", :status => 401, :headers => {
+                  'Content-Type' => 'text/html',
+                  'Transfer-Encoding' => 'Chunked',
+                  'Connection' => 'Keep-Alive',
+                  'Keep-Alive' => 'timeout=5, max=100',
+                  'Public' => 'GET HEAD',
+                  'Proxy-Authenticate' => 'Basic',
+                  'X-Drop-Test' => 'ShouldAlwaysHappen',
+                  'Upgrade' => 'dummy'
+                })
+    response = Rack::Prerender.new(@app).call(request)
+
+    assert_equal response[2], ["<html></html>"]
+    assert_equal response[0], 401
+    assert_equal( { 'content-type' => 'text/html', 'x-drop-test' => 'ShouldAlwaysHappen'}, response[1] )
+  end
+
+it "should return a prerendered response stripped of custom-defined hop-by-hop headers" do
+    request = Rack::MockRequest.env_for "/", "HTTP_USER_AGENT" => bot
+    stub_request(:get, @prerender.build_api_url(request)).
+      with(:headers => { 'User-Agent' => bot }).
+      to_return(:body => "<html></html>", :status => 200, :headers => {
+                  'Content-Type' => 'text/html',
+                  'Connection' => 'Close, X-Drop-Test',
+                  'X-Drop-Test' => 'ShouldNeverHappen'
+                })
+    response = Rack::Prerender.new(@app).call(request)
+
+    assert_equal response[2], ["<html></html>"]
+    assert_equal response[0], 200
+    assert_equal( { 'content-type' => 'text/html' }, response[1] )
+  end
 
   describe '#buildApiUrl' do
     it "should build the correct api url with the default url" do


### PR DESCRIPTION
This PR introduces discarding hop-by-hop headers from prerender responses (with respective test cases).

As mentioned in [#512](https://github.com/prerender/prerender/issues/512#issuecomment-731305332), the rails middleware is acting as a proxy but isn't discarding hop-by-hop headers. Since this behaviour [violates HTTP protocol](https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1), it's causing issues further down the line (e.g. in our case it was failing all the prerender requests routed by nginx).

Excerpt from RFC2616 attached below:
>    For the purpose of defining the behavior of caches and non-caching
>    proxies, we divide HTTP headers into two categories:
> 
>       - End-to-end headers, which are  transmitted to the ultimate
>         recipient of a request or response. End-to-end headers in
>         responses MUST be stored as part of a cache entry and MUST be
>         transmitted in any response formed from a cache entry.
> 
>       - Hop-by-hop headers, which are meaningful only for a single
>         transport-level connection, and are not stored by caches or
>         forwarded by proxies.
> 
>    The following HTTP/1.1 headers are hop-by-hop headers:
> 
>       - Connection
>       - Keep-Alive
>       - Proxy-Authenticate
>       - Proxy-Authorization
>       - TE
>       - Trailers
>       - Transfer-Encoding
>       - Upgrade
> 
>    All other headers defined by HTTP/1.1 are end-to-end headers.
> 
>    Other hop-by-hop headers MUST be listed in a Connection header