### PR TITLE
Add support for timeouts on proxied HTTP request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Not Yet Released
+
+- Feature: Add support for timeouts on proxied HTTP request (seven1m)
+- Fix: Discard hop-by-hop headers (mewa)
+- Fix: Do not check blacklist/whitelist if `is_requesting_prerendered_page` is false (rporrasluc)
+
+# 1.7.0 - June 03, 2020
+
+Last version maintained by https://github.com/thoop

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Option to hard-set the protocol for Prerender accessing your site instead of the
 config.middleware.use Rack::Prerender, protocol: 'https'
 ```
 
+### timeouts
+
+You can configure Net::HTTP [`open_timeout`](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout) and [`read_timeout`](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout) on the proxy request.
+```ruby
+config.middleware.use Rack::Prerender, open_timeout: 2, read_timeout: 10
+```
+
 ## Caching
 
 This rails middleware is ready to be used with [redis](http://redis.io/) or [memcached](http://memcached.org/) to return prerendered pages in milliseconds.

--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -169,6 +169,8 @@ module Rack
         req.basic_auth(ENV['PRERENDER_USERNAME'], ENV['PRERENDER_PASSWORD']) if @options[:basic_auth]
         http = Net::HTTP.new(url.host, url.port)
         http.use_ssl = true if url.scheme == 'https'
+        http.open_timeout = @options[:open_timeout] if @options[:open_timeout]
+        http.read_timeout = @options[:read_timeout] if @options[:read_timeout]
         response = http.request(req)
         if response['Content-Encoding'] == 'gzip'
           response.body = ActiveSupport::Gzip.decompress(response.body)

--- a/test/lib/prerender_rails.rb
+++ b/test/lib/prerender_rails.rb
@@ -160,6 +160,23 @@ describe Rack::Prerender do
   end
 
 
+  it "should continue to app routes if open_timeout is exceeded" do
+    request = Rack::MockRequest.env_for "/", "HTTP_USER_AGENT" => bot
+    stub_request(:get, @prerender.build_api_url(request)).to_raise(Net::OpenTimeout)
+    response = Rack::Prerender.new(@app, open_timeout: 0.1).call(request)
+
+    assert_equal [200, {}, ""], response
+  end
+
+
+  it "should continue to app routes if read_timeout is exceeded" do
+    request = Rack::MockRequest.env_for "/", "HTTP_USER_AGENT" => bot
+    stub_request(:get, @prerender.build_api_url(request)).to_raise(Net::ReadTimeout)
+    response = Rack::Prerender.new(@app, read_timeout: 0.1).call(request)
+
+    assert_equal [200, {}, ""], response
+  end
+
   describe '#buildApiUrl' do
     it "should build the correct api url with the default url" do
       request = Rack::MockRequest.env_for "https://google.com/search?q=javascript"


### PR DESCRIPTION
We recently had an issue where our requests to prerender.io were taking an insanely long time, tying up all our web server threads. Consequently, prerender.io could not make requests to our app because all the server threads were stalled, so it became A Thing™.

Our solution is to limit proxy requests with some timeout settings.

I hope this is worthy of a merge; please let me know if I can make any changes to this!