### PR TITLE
fix: incorrect Content-Length for UTF-8 response bodies

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -187,7 +187,7 @@ module Rack
         response = http.request(req)
         if response['Content-Encoding'] == 'gzip'
           response.body = ActiveSupport::Gzip.decompress(response.body)
-          response['Content-Length'] = response.body.length
+          response['Content-Length'] = response.body.bytesize
           response.delete('Content-Encoding')
         end
 


### PR DESCRIPTION
As per: [Ruby 1.9's String - All Strings are now Encoded](http://graysoftinc.com/character-encodings/ruby-19s-string)

```ruby
# the attached encoding
puts utf8_resume.encoding.name    # >> UTF-8
puts latin1_resume.encoding.name  # >> ISO-8859-1

# length is now encoded data length or characters
puts utf8_resume.length    # >> 6 
puts latin1_resume.length  # >> 6

# but we can ask for a raw bytesize() to see they are different
puts utf8_resume.bytesize    # >> 8
puts latin1_resume.bytesize  # >> 6

# we now index by encoded data (again characters)
puts utf8_resume[2..4]    # >> sum
puts latin1_resume[2..4]  # >> sum
```

And per: [References - HTTP - HTTP headers - Content-Length](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length)

> The `Content-Length` header indicates the size of the message body, in **bytes**, sent to the recipient.