### PR TITLE
Add Pinterestbot to crawler_user_agents

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -33,6 +33,7 @@ module Rack
         'showyoubot',
         'outbrain',
         'pinterest/0.',
+        'Pinterestbot',
         'developers.google.com/+/web/snippet',
         'www.google.com/webmasters/tools/richsnippets',
         'slackbot',


### PR DESCRIPTION
https://help.pinterest.com/en/business/article/pinterest-crawler

> Our user agent is:
>
>Pinterest/0.2 (+https://www.pinterest.com/bot.html)
>Mozilla/5.0 (compatible; Pinterestbot/1.0; +https://www.pinterest.com/bot.html)
>Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Pinterestbot/1.0; +https://www.pinterest.com/bot.html)