### PR TITLE
Add Customizable HTTP timeouts

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -99,6 +99,11 @@ module Rack
       @options[:blacklist] = [@options[:blacklist]] if @options[:blacklist].is_a? String
       @extensions_to_ignore = @options[:extensions_to_ignore] if @options[:extensions_to_ignore]
       @crawler_user_agents = @options[:crawler_user_agents] if @options[:crawler_user_agents]
+
+      timeout = options.delete(:timeout)
+      @options[:open_timeout] = @options[:open_timeout] || timeout
+      @options[:read_timeout] = @options[:read_timeout] || timeout
+
       @app = app
     end
 
@@ -181,11 +186,9 @@ module Rack
         }
         headers['X-Prerender-Token'] = ENV['PRERENDER_TOKEN'] if ENV['PRERENDER_TOKEN']
         headers['X-Prerender-Token'] = @options[:prerender_token] if @options[:prerender_token]
-        req = Net::HTTP::Get.new(url.request_uri, headers)
-        req.basic_auth(ENV['PRERENDER_USERNAME'], ENV['PRERENDER_PASSWORD']) if @options[:basic_auth]
-        http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = true if url.scheme == 'https'
-        response = http.request(req)
+
+        http = build_http_client(url)
+        response = http.request(build_http_request(url, headers))
         if response['Content-Encoding'] == 'gzip'
           response.body = ActiveSupport::Gzip.decompress(response.body)
           response['Content-Length'] = response.body.bytesize
@@ -210,6 +213,19 @@ module Rack
       end
     end
 
+    def build_http_request(uri, headers)
+      Net::HTTP::Get.new(uri.request_uri, headers).tap do |req|
+        req.basic_auth(ENV["PRERENDER_USERNAME"], ENV["PRERENDER_PASSWORD"]) if @options[:basic_auth]
+      end
+    end
+
+    def build_http_client(uri)
+      Net::HTTP.new(uri.host, uri.port).tap do |http|
+        http.use_ssl = true if uri.scheme == "https"
+        http.open_timeout = @options[:open_timeout] if @options[:open_timeout]
+        http.read_timeout = @options[:read_timeout] if @options[:read_timeout]
+      end
+    end
 
     def build_api_url(env)
       new_env = env

--- a/test/lib/prerender_rails.rb
+++ b/test/lib/prerender_rails.rb
@@ -257,4 +257,39 @@ it "should return a prerendered response stripped of custom-defined hop-by-hop h
     end
   end
 
+  describe "#build_http_client" do
+    it "should set use_ssl for https uri" do
+      @prerender = Rack::Prerender.new(@app)
+      uri = URI.parse("https://google.com/search?q=javascript")
+      http_client = @prerender.build_http_client(uri)
+
+      assert_equal true, http_client.use_ssl?
+    end
+
+    it "should set use_ssl for http uri" do
+      @prerender = Rack::Prerender.new(@app)
+      uri = URI.parse("http://google.com/search?q=javascript")
+      http_client = @prerender.build_http_client(uri)
+
+      assert_equal false, http_client.use_ssl?
+    end
+
+    it "should use global timeout if provided" do
+      @prerender = Rack::Prerender.new(@app, timeout: 10)
+      uri = URI.parse("https://google.com/search?q=javascript")
+      http_client = @prerender.build_http_client(uri)
+
+      assert_equal 10, http_client.open_timeout
+      assert_equal 10, http_client.read_timeout
+    end
+
+    it "should respect open_timeout" do
+      @prerender = Rack::Prerender.new(@app, open_timeout: 5, read_timeout: 10)
+      uri = URI.parse("https://google.com/search?q=javascript")
+      http_client = @prerender.build_http_client(uri)
+
+      assert_equal 5, http_client.open_timeout
+      assert_equal 10, http_client.read_timeout
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the ability to customize the HTTP timeouts used when fetching content for prerendering via `Net::HTTP`:

* `timeout` for both `read_timeout` and `open_timeout`
* `read_timeout`
* `open_timeout`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable Net::HTTP timeouts and refactors HTTP request/client creation with accompanying tests.
> 
> - **Prerender middleware (`lib/prerender_rails.rb`)**:
>   - Add configurable timeouts: supports global `timeout`, and per-option `open_timeout` and `read_timeout` (applied to `Net::HTTP`).
>   - Refactor HTTP calls:
>     - New `build_http_client(uri)` sets `use_ssl`, `open_timeout`, and `read_timeout`.
>     - New `build_http_request(uri, headers)` builds `Net::HTTP::Get` and applies basic auth when enabled.
>     - `get_prerendered_page_response` now uses these helpers.
> - **Tests (`test/lib/prerender_rails.rb`)**:
>   - Add specs for `build_http_client` covering SSL selection and timeout configuration.
>   - Keep existing URL-building tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb3ede2d601a9054dfa8186f781c1b40d06d4123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->