### PR TITLE
Rack 2 and Rack 3 compatibility

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -242,7 +242,10 @@ module Rack
 
 
     def build_rack_response_from_prerender(prerendered_response)
-      response = Rack::Response.new(prerendered_response.body, prerendered_response.code, prerendered_response)
+      headers = {}
+      prerendered_response.each_header { |key, value| headers[key] = value }
+
+      response = Rack::Response.new(prerendered_response.body, prerendered_response.code, headers)
 
       @options[:build_rack_response_from_prerender].call(response, prerendered_response) if @options[:build_rack_response_from_prerender]
 

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '>= 2.2'
   spec.add_dependency 'activesupport', '>= 0'
 
-  spec.add_development_dependency "bundler", ">= 2.1.2"
+  spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"
 end

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '>= 2.2'
   spec.add_dependency 'activesupport', '>= 0'
 
-  spec.add_development_dependency "bundler", "~> 4.0"
+  spec.add_development_dependency "bundler", ">= 2.1.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"
 end

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rack', '~> 2.2.2'
+  spec.add_dependency 'rack', '>= 2.2'
   spec.add_dependency 'activesupport', '>= 0'
 
-  spec.add_development_dependency "bundler", "~> 2.1.2"
+  spec.add_development_dependency "bundler", "~> 4.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"
 end

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rack', '>= 2.2'
+  spec.add_dependency 'rack', '>= 2.2', '< 4'
   spec.add_dependency 'activesupport', '>= 0'
 
   spec.add_development_dependency "bundler", ">= 2.1"

--- a/test/lib/prerender_rails.rb
+++ b/test/lib/prerender_rails.rb
@@ -21,7 +21,7 @@ describe Rack::Prerender do
 
     assert_equal response[2], ["<html></html>"]
     assert_equal response[0], 301
-    assert_equal( { 'location' => 'http://google.com'}, response[1] )
+    assert_equal 'http://google.com', response[1]['location']
   end
 
 
@@ -156,7 +156,7 @@ describe Rack::Prerender do
 
     assert_equal ["<html>cached2</html>"], response[2]
     assert_equal response[0], 200
-    assert_equal( { 'test' => 'test2Header'}, response[1] )
+    assert_equal 'test2Header', response[1]['test']
   end
 
   it "should return a prerendered response stripped of hop-by-hop headers" do
@@ -177,7 +177,10 @@ describe Rack::Prerender do
 
     assert_equal response[2], ["<html></html>"]
     assert_equal response[0], 401
-    assert_equal( { 'content-type' => 'text/html', 'x-drop-test' => 'ShouldAlwaysHappen'}, response[1] )
+    assert_equal 'text/html', response[1]['content-type']
+    assert_equal 'ShouldAlwaysHappen', response[1]['x-drop-test']
+    assert_nil response[1]['transfer-encoding']
+    assert_nil response[1]['connection']
   end
 
 it "should return a prerendered response stripped of custom-defined hop-by-hop headers" do
@@ -193,7 +196,9 @@ it "should return a prerendered response stripped of custom-defined hop-by-hop h
 
     assert_equal response[2], ["<html></html>"]
     assert_equal response[0], 200
-    assert_equal( { 'content-type' => 'text/html' }, response[1] )
+    assert_equal 'text/html', response[1]['content-type']
+    assert_nil response[1]['x-drop-test']
+    assert_nil response[1]['connection']
   end
 
   describe '#buildApiUrl' do


### PR DESCRIPTION
Proivide compatibility for Rack 2 and Rack 3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how upstream HTTP headers are translated into Rack responses, which could subtly affect header casing/contents and cache/redirect behavior. Dependency range widening to `rack < 4` may expose incompatibilities in environments not covered by tests.
> 
> **Overview**
> Improves Rack 2/3 compatibility by changing `build_rack_response_from_prerender` to pass a plain header hash (copied via `each_header`) into `Rack::Response` instead of the raw `Net::HTTPResponse` object.
> 
> Relaxes gem constraints to allow `rack >= 2.2, < 4` and updates tests to assert individual response headers (and hop-by-hop header stripping) rather than exact header-hash equality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea02b9affc5921d02aca26d84e05efc09fd4dea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->